### PR TITLE
Fix Gigalixir Asset Build

### DIFF
--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,1 +1,3 @@
 compile="phoenix_static_buildpack.compile"
+node_version=9.4.0
+


### PR DESCRIPTION
I was able to reproduce the error you sent me
```
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Cannot find module './SourceMapPackager'
```

I tried a few things and the error went away when I specified the node_version and got the following output which I assume is expected. I wasn't able to test the actual app though because I don't know what configuration variables are needed so lemme know if this still doesn't work.
```
...
       uglify-to-browserify@1.0.2 /tmp/build/node_modules/uglify-to-browserify
       npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.1.3 (node_modules/fsevents):
       npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.1.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
       
       up to date in 4.847s
       Running custom compile
       ⏳  Building...
       
       ⏳  Building app.js...
       ⏳  Building agent-status.js...
       ⏳  Building throttle.js...
       Dropping side-effect-free statement [0:56,8]
       Dropping side-effect-free statement [0:61,8]
       Dropping side-effect-free statement [0:65,8]
       Side effects in initialization of unused variable in_call [0:75,10]
       Side effects in initialization of unused variable ready [0:76,10]
       Side effects in initialization of unused variable wrap_up [0:77,10]
       Dropping side-effect-free statement [0:59,8]
       Dropping side-effect-free statement [0:64,8]
       Dropping side-effect-free statement [0:68,8]
       ⏳  Building phoenix.js...
       ⏳  Building preact.esm.js...
       Dropping side-effect-free statement [0:56,8]
       Dropping side-effect-free statement [0:61,8]
       Dropping side-effect-free statement [0:65,8]
       Side effects in initialization of unused variable in_call [0:75,10]
       Side effects in initialization of unused variable ready [0:76,10]
       Side effects in initialization of unused variable wrap_up [0:77,10]
       Dropping side-effect-free statement [0:59,8]
       Dropping side-effect-free statement [0:64,8]
       Dropping side-effect-free statement [0:68,8]
       Dropping duplicated definition of variable key [0:483,7]
       Dropping duplicated definition of variable i [0:494,11]
       Dropping duplicated definition of variable key [0:483,7]
       Dropping duplicated definition of variable i [0:494,11]
       Side effects in initialization of unused variable ref [0:318,10]
       Boolean && always false [0:811,8]
       Dropping duplicated definition of variable status [0:1107,14]
       Boolean && always false [0:1228,8]
       Dropping unreachable code [0:1257,6]
       Declarations in unreachable code! [0:1257,6]
       Side effects in initialization of unused variable Socket [0:727,4]
       Side effects in initialization of unused variable Presence [0:1267,4]
       ✨  Built in 3.53s.
       Side effects in initialization of unused variable ref [0:318,10]
       Boolean && always false [0:811,8]
       Dropping duplicated definition of variable status [0:1107,14]
       Boolean && always false [0:1228,8]
       Dropping unreachable code [0:1257,6]
       Declarations in unreachable code! [0:1257,6]
       Side effects in initialization of unused variable Socket [0:727,4]
       Side effects in initialization of unused variable Presence [0:1267,4]
       Check your digested files at "priv/static"
       
-----> Finalizing build
       Caching versions for future builds
       Creating runtime environment
=====> Downloading Buildpack: https://github.com/gigalixir/gigalixir-buildpack-distillery.git
=====> Detected Framework: Distillery
       Compiling 1 file (.ex)
       ==> Assembling release..
...
```